### PR TITLE
Renamed buildCommand's displayName “Test”→“MetalCompilerTool”

### DIFF
--- a/Plugins/MetalCompilerPlugin/MetalPlugin.swift
+++ b/Plugins/MetalCompilerPlugin/MetalPlugin.swift
@@ -14,7 +14,7 @@ struct MetalPlugin: BuildToolPlugin {
         Diagnostics.remark("Running...")
         return [
             .buildCommand(
-                displayName: "Test",
+                displayName: "MetalCompilerTool",
                 executable: try context.tool(named: "MetalCompilerTool").path,
                 arguments: [
                     "--output", context.pluginWorkDirectory.appending(["debug.metallib"]).string,


### PR DESCRIPTION
The displayName of “Test” can appear in dependent projects' build logs, and is pretty confusing.  Using the name of this project — “MetalCompilerTool” makes things much clearer.